### PR TITLE
Cd pipeline

### DIFF
--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -4,6 +4,7 @@
 #   - flake8
 #   - nose
 #   - buildah (ClusterTask)
+#   - openshift-client (ClusterTask)
 #
 ---
 apiVersion: tekton.dev/v1beta1
@@ -81,3 +82,22 @@ spec:
       runAfter:
         - tests
         - lint
+
+    - name: deploy
+      workspaces:
+        - name: manifest-dir
+          workspace: pipeline-workspace
+      taskRef:
+        name: openshift-client
+        kind: ClusterTask
+      params:
+        - name: SCRIPT
+          value: |
+            echo "Updating manifest..."
+            sed -i "s|IMAGE_NAME_HERE|$(params.build-image)|g" deploy/deployment.yaml
+            cat deploy/deployment.yaml
+            echo "Deploying to OpenShift..."
+            oc apply -f deploy/
+            oc get pods -l app=accounts
+      runAfter:
+        - build

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -50,3 +50,17 @@ spec:
           value: ["--count", "--max-complexity=10", "--max-line-length=127", "--statistics"]
       runAfter:
         - clone
+        
+    - name: tests
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      taskRef:
+        name: nose
+      params:
+      - name: database_uri
+        value: "sqlite:///test.db"
+      - name: args
+        value: "-v --with-spec --spec-color"
+      runAfter:
+        - clone

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -2,6 +2,8 @@
 # This pipeline needs the following tasks from Tekton Hub
 #   - git-clone
 #   - flake8
+#   - nose
+#   - buildah (ClusterTask)
 #
 ---
 apiVersion: tekton.dev/v1beta1
@@ -15,6 +17,7 @@ spec:
     - name: repo-url
     - name: branch
       default: main
+    - name: build-image
   tasks:
     - name: init
       workspaces:
@@ -58,9 +61,23 @@ spec:
       taskRef:
         name: nose
       params:
-      - name: database_uri
-        value: "sqlite:///test.db"
-      - name: args
-        value: "-v --with-spec --spec-color"
+        - name: database_uri
+          value: "sqlite:///test.db"
+        - name: args
+          value: "-v --with-spec --spec-color"
       runAfter:
         - clone
+
+    - name: build
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      taskRef:
+        name: buildah
+        kind: ClusterTask
+      params:
+        - name: IMAGE
+          value: "$(params.build-image)"
+      runAfter:
+        - tests
+        - lint


### PR DESCRIPTION
## Summary by Sourcery

Add continuous deployment steps to the Tekton pipeline, including testing with nose, image building with buildah, and OpenShift deployment with the openshift-client task, while parameterizing the image name and defining task sequencing.

CI:
- Include `nose`, `buildah`, and `openshift-client` ClusterTasks in pipeline requirements
- Add `tests` step with the nose task, `build` step with buildah, and `deploy` step with openshift-client, linked via runAfter dependencies
- Introduce a `build-image` pipeline parameter and pass it to the build and deploy tasks